### PR TITLE
Fix python 3.6 strptime timezone interpretation, bump minor to .1

### DIFF
--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -5,6 +5,8 @@ import requests
 import datetime
 import pytz
 import xml.etree.cElementTree as Etree
+# For python 3.6 strptime fix
+import re
 
 USERNAME = ''
 PASSWORD = ''
@@ -405,7 +407,10 @@ class Haanna(object):
                                         + "']/name").text
                 schema_date = root.find("rule[@id='" + schema_id
                                         + "']/modified_date").text
-                schema_time = datetime.datetime.strptime(schema_date,
+                # Python 3.6 fix (%z %Z issue)
+                corrected = re.sub(r'([-+]\d{2}):(\d{2})(?:(\d{2}))?$', 
+                                   r'\1\2\3', schema_date)
+                schema_time = datetime.datetime.strptime(corrected,
                                                          date_format)
                 schemas[schema_name] = (schema_time -
                                         epoch).total_seconds()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.10.0',
+    version='0.10.1',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',


### PR DESCRIPTION
See #9 - During testing found out python 3.6 interpretes %z differently than 3.7, using the corrected string will make it work on both versions.