### PR TITLE
Implement get_last_active_schema as a separate function

### DIFF
--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -361,6 +361,7 @@ class Haanna:
         if target_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value  
         return None
 
@@ -370,6 +371,7 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -370,7 +370,6 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -340,7 +340,6 @@ class Haanna:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             if measurement:
                 value = float(measurement)
-                value = '{:.1f}'.format(round(value, 1))
                 return value
         return None
 
@@ -352,7 +351,6 @@ class Haanna:
                 root, current_temp_point_log_id
             )
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -362,7 +360,6 @@ class Haanna:
         if target_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value  
         return None
 
@@ -372,7 +369,6 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -340,6 +340,7 @@ class Haanna:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             if measurement:
                 value = float(measurement)
+                value = '{:.1f}'.format(round(value, 1))
                 return value
         return None
 
@@ -351,7 +352,6 @@ class Haanna:
                 root, current_temp_point_log_id
             )
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -361,6 +361,7 @@ class Haanna:
         if target_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value  
         return None
 
@@ -370,6 +371,7 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -339,7 +339,9 @@ class Haanna:
         if point_log_id:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             if measurement:
-                return float(measurement)
+                value = float(measurement)
+                value = '{:.1f}'.format(round(value, 1))
+                return value
         return None
 
     def get_current_temperature(self, root):
@@ -349,7 +351,9 @@ class Haanna:
             measurement = self.get_measurement_from_point_log(
                 root, current_temp_point_log_id
             )
-            return float(measurement)
+            value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
+            return value
         return None
 
     def get_target_temperature(self, root):
@@ -357,7 +361,9 @@ class Haanna:
         target_temp_log_id = self.get_point_log_id(root, "target_temperature")
         if target_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
-            return float(measurement)
+            value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
+            return value  
         return None
 
     def get_thermostat_temperature(self, root):
@@ -365,7 +371,9 @@ class Haanna:
         thermostat_log_id = self.get_point_log_id(root, "thermostat")
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
-            return float(measurement)
+            value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
+            return value
         return None
 
     def get_outdoor_temperature(self, root):
@@ -374,7 +382,7 @@ class Haanna:
         if outdoor_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, outdoor_temp_log_id)
             value = float(measurement)
-            value = round(value, 1)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -384,7 +392,7 @@ class Haanna:
         if point_log_id:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             value = float(measurement)
-            value = round(value, 1)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -394,7 +402,7 @@ class Haanna:
         if point_log_id:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             value = float(measurement)
-            value = round(value, 1)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -403,7 +411,9 @@ class Haanna:
         point_log_id = self.get_point_log_id(root, "central_heater_water_pressure")
         if point_log_id:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
-            return float(measurement)
+            value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
+            return value
         return None
 
     def __get_temperature_uri(self, root):

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -1,6 +1,5 @@
-"""
-Plugwise Anna HomeAssistant component
-"""
+"""Plugwise Anna Home Assistant component."""
+
 import requests
 import datetime
 import pytz
@@ -17,91 +16,77 @@ ANNA_APPLIANCES = "/core/appliances"
 ANNA_RULES = "/core/rules"
 
 
-class Haanna(object):
+class Haanna:
+    """Define the Haanna object."""
+
     def __init__(
-        self,
-        username,
-        password,
-        host,
-        port,
-        legacy_anna=False,
+        self, username, password, host, port, legacy_anna=False,
     ):
-        """Constructor for this class"""
+        """Set the constructor for this class."""
         self.legacy_anna = legacy_anna
         self._username = username
         self._password = password
         self._endpoint = "http://" + host + ":" + str(port)
 
     def ping_anna_thermostat(self):
-        """Ping the thermostat to see if it's online"""
-        r = requests.get(
+        """Ping the thermostat to see if it's online."""
+        ping = requests.get(
             self._endpoint + ANNA_PING_ENDPOINT,
             auth=(self._username, self._password),
             timeout=10,
         )
 
-        if r.status_code != 404:
-            raise ConnectionError(
-                "Could not connect to the gateway."
-            )
+        if ping.status_code != 404:
+            raise ConnectionError("Could not connect to the gateway.")
 
         return True
 
     def get_direct_objects(self):
-        r = requests.get(
-            self._endpoint + ANNA_DIRECT_OBJECTS_ENDPOINT,
-            auth=(self._username, self._password),
-            timeout=10,
+        """Collect the direct_objects XML-data."""
+        xml = requests.get(
+              self._endpoint + ANNA_DIRECT_OBJECTS_ENDPOINT,
+              auth=(self._username, self._password),
+              timeout=10,
         )
 
-        if r.status_code != requests.codes.ok:
-            raise ConnectionError(
-                "Could not get the direct objects."
-            )
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
+            raise ConnectionError("Could not get the direct objects.")
 
-        return Etree.fromstring(self.escape_illegal_xml_characters(r.text))
+        return Etree.fromstring(self.escape_illegal_xml_characters(xml.text))
 
     def get_domain_objects(self):
-        r = requests.get(
-            self._endpoint + ANNA_DOMAIN_OBJECTS_ENDPOINT,
-            auth=(self._username, self._password),
-            timeout=10,
+        """Collect the domain_objects XML-data."""
+        xml = requests.get(
+              self._endpoint + ANNA_DOMAIN_OBJECTS_ENDPOINT,
+              auth=(self._username, self._password),
+              timeout=10,
         )
 
-        if r.status_code != requests.codes.ok:
-            raise ConnectionError(
-                "Could not get the domain objects."
-            )
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
+            raise ConnectionError("Could not get the domain objects.")
 
-        return Etree.fromstring(self.escape_illegal_xml_characters(r.text))
+        return Etree.fromstring(self.escape_illegal_xml_characters(xml.text))
 
     @staticmethod
     def escape_illegal_xml_characters(root):
-        return re.sub(r'&([^a-zA-Z#])',r'&amp;\1',root)
-    
+        """Replace illegal &-characters."""
+        return re.sub(r"&([^a-zA-Z#])", r"&amp;\1", root)
+
     def get_presets(self, root):
-        """Gets the presets from the thermostat"""
+        """Get the presets from the thermostat."""
         if self.legacy_anna:
             return self.__get_preset_dictionary_v1(root)
-        else:
-            rule_id = self.get_rule_id_by_template_tag(
-                root,
-                "zone_setpoint_and_state_based_on_preset",
-            )[0]
+        rule_id = self.get_rule_id_by_template_tag(
+            root, "zone_setpoint_and_state_based_on_preset",
+        )[0]
 
+        if rule_id is None:
+            rule_id = self.get_rule_id_by_name(root, "Thermostat presets")
             if rule_id is None:
-                rule_id = self.get_rule_id_by_name(
-                    root, "Thermostat presets"
-                )
-                if rule_id is None:
-                    raise RuleIdNotFoundException(
-                        "Could not find the rule id."
-                    )
+                raise RuleIdNotFoundException("Could not find the rule id.")
 
-            presets = self.get_preset_dictionary(
-                root, rule_id
-            )
-            return presets
+        presets = self.get_preset_dictionary(root, rule_id)
+        return presets
 
     def get_schema_names(self, root):
         """Get schemas or schedules available."""
@@ -121,41 +106,36 @@ class Haanna(object):
         return result
 
     def set_schema_state(self, root, schema, state):
-        """Sends a set request to the schema with the given name"""
-        schema_rule_id = self.get_rule_id_by_name(
-            root, str(schema)
-        )
-        templates = root.findall(
-            ".//*[@id='{}']/template".format(schema_rule_id)
-        )
+        """Send a set request to the schema with the given name."""
+        schema_rule_id = self.get_rule_id_by_name(root, str(schema))
+        templates = root.findall(".//*[@id='{}']/template".format(schema_rule_id))
         template_id = None
         for rule in templates:
-            template_id = rule.attrib['id']
+            template_id = rule.attrib["id"]
 
-        uri = '{};id={}'.format(ANNA_RULES, schema_rule_id)
+        uri = "{};id={}".format(ANNA_RULES, schema_rule_id)
 
         state = str(state)
-        data = '<rules><rule id="{}"><name><![CDATA[{}]]></name>' \
-               '<template id="{}" /><active>{}</active></rule>' \
-               '</rules>'.format(schema_rule_id, schema, template_id, state)
-
-        r = requests.put(
-            self._endpoint + uri,
-            auth=(self._username, self._password),
-            data=data,
-            headers={'Content-Type': 'text/xml'},
-            timeout=10
+        data = (
+            '<rules><rule id="{}"><name><![CDATA[{}]]></name>'
+            '<template id="{}" /><active>{}</active></rule>'
+            "</rules>".format(schema_rule_id, schema, template_id, state)
         )
 
-        if r.status_code != requests.codes.ok:
+        xml = requests.put(
+              self._endpoint + uri,
+              auth=(self._username, self._password),
+              data=data,
+              headers={"Content-Type": "text/xml"},
+              timeout=10,
+        )
+
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
             CouldNotSetTemperatureException(
-                "Could not set the schema to {}.".format(
-                    state
-                )
-                + r.text
+                "Could not set the schema to {}.".format(state) + xml.text
             )
 
-        return '{} {}'.format(r.text, data)
+        return "{} {}".format(xml.text, data)
 
     def get_active_schema_name(self, root):
         """Get active schema."""
@@ -170,15 +150,13 @@ class Haanna(object):
             if result == []:
                 return None
             return result
-            
-        else:
-            locator = "zone_preset_based_on_time_and_presence_with_override"
-            rule_id = self.get_rule_id_by_template_tag(root, locator)
-            if rule_id is None:
-                return None
-            else:
-                schema_active = self.get_active_name(root, rule_id)
-                return schema_active
+
+        locator = "zone_preset_based_on_time_and_presence_with_override"
+        rule_id = self.get_rule_id_by_template_tag(root, locator)
+        if rule_id is None:
+            return None
+        schema_active = self.get_active_name(root, rule_id)
+        return schema_active
 
     def get_last_active_schema_name(self, root):
         """Determine the last active schema (not used for legacy Anna)."""
@@ -187,10 +165,9 @@ class Haanna(object):
         last_schema_active = self.get_last_active_name(root, rule_id)
         return last_schema_active
 
-    def get_schema_state(self, root):
-        """
-        Gets the mode the thermostat is in (active schedule is true or false)
-        """
+    @staticmethod
+    def get_schema_state(root):
+        """Get the mode the thermostat is in (active schedule is true or false)."""
         log_type = "schedule_state"
         locator = (
             "appliance[type='thermostat']/logs/point_log[type='"
@@ -203,116 +180,93 @@ class Haanna(object):
 
     @staticmethod
     def get_rule_id_by_template_tag(root, rule_name):
-        """Gets the rule ID based on template_tag"""
+        """Get the rule ID based on template_tag."""
         schema_ids = []
         rules = root.findall("rule")
         for rule in rules:
-            if (
-                rule.find("template").attrib["tag"]
-                == rule_name
-            ):
+            if rule.find("template").attrib["tag"] == rule_name:
                 schema_ids.append(rule.attrib["id"])
         if schema_ids == []:
             return None
         return schema_ids
 
     def set_preset(self, root, preset):
-        """Sets the given preset on the thermostat"""
+        """Set the given preset on the thermostat."""
         if self.legacy_anna:
             return self.__set_preset_v1(root, preset)
-        else:
-            locator = (
-                "appliance[type='thermostat']/location"
-            )
-            location_id = root.find(locator).attrib["id"]
+        locator = "appliance[type='thermostat']/location"
+        location_id = root.find(locator).attrib["id"]
 
-            locations_root = Etree.fromstring(
-                requests.get(
-                    self._endpoint + ANNA_LOCATIONS_ENDPOINT,
-                    auth=(self._username, self._password),
-                    timeout=10,
-                ).text
-            )
-
-            current_location = locations_root.find(
-                "location[@id='" + location_id + "']"
-            )
-            location_name = current_location.find(
-                "name"
-            ).text
-            location_type = current_location.find(
-                "type"
-            ).text
-
-            r = requests.put(
-                self._endpoint
-                + ANNA_LOCATIONS_ENDPOINT
-                + ";id="
-                + location_id,
+        locations_root = Etree.fromstring(
+            requests.get(
+                self._endpoint + ANNA_LOCATIONS_ENDPOINT,
                 auth=(self._username, self._password),
-                data="<locations>"
-                + '<location id="'
-                + location_id
-                + '">'
-                + "<name>"
-                + location_name
-                + "</name>"
-                + "<type>"
-                + location_type
-                + "</type>"
-                + "<preset>"
-                + preset
-                + "</preset>"
-                + "</location>"
-                + "</locations>",
-                headers={"Content-Type": "text/xml"},
                 timeout=10,
-            )
+            ).text
+        )
 
-            if r.status_code != requests.codes.ok:
-                raise CouldNotSetPresetException(
-                    "Could not set the "
-                    "given preset: " + r.text
-                )
-            return r.text
+        current_location = locations_root.find("location[@id='" + location_id + "']")
+        location_name = current_location.find("name").text
+        location_type = current_location.find("type").text
+
+        xml = requests.put(
+              self._endpoint + ANNA_LOCATIONS_ENDPOINT + ";id=" + location_id,
+              auth=(self._username, self._password),
+              data="<locations>"
+              + '<location id="'
+              + location_id
+              + '">'
+              + "<name>"
+              + location_name
+              + "</name>"
+              + "<type>"
+              + location_type
+              + "</type>"
+              + "<preset>"
+              + preset
+              + "</preset>"
+              + "</location>"
+              + "</locations>",
+              headers={"Content-Type": "text/xml"},
+              timeout=10,
+        )
+
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
+            raise CouldNotSetPresetException(
+                "Could not set the " "given preset: " + xml.text
+            )
+        return xml.text
 
     def __set_preset_v1(self, root, preset):
-        """Sets the given preset on the thermostat for V1"""
-        locator = (
-            "rule/directives/when/then[@icon='"
-            + preset
-            + "'].../.../..."
-        )
+        """Set the given preset on the thermostat for V1."""
+        locator = "rule/directives/when/then[@icon='" + preset + "'].../.../..."
         rule = root.find(locator)
         if rule is None:
+            raise CouldNotSetPresetException("Could not find preset '" + preset + "'")
+
+        rule_id = rule.attrib["id"]
+        xml = requests.put(
+              self._endpoint + ANNA_RULES,
+              auth=(self._username, self._password),
+              data="<rules>"
+              + '<rule id="'
+              + rule_id
+              + '">'
+              + "<active>true</active>"
+              + "</rule>"
+              + "</rules>",
+              headers={"Content-Type": "text/xml"},
+              timeout=10,
+        )
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
             raise CouldNotSetPresetException(
-                "Could not find preset '" + preset + "'"
+                "Could not set the given " "preset: " + xml.text
             )
+        return xml.text
 
-        else:
-            rule_id = rule.attrib["id"]
-            r = requests.put(
-                self._endpoint + ANNA_RULES,
-                auth=(self._username, self._password),
-                data="<rules>"
-                + '<rule id="'
-                + rule_id
-                + '">'
-                + "<active>true</active>"
-                + "</rule>"
-                + "</rules>",
-                headers={"Content-Type": "text/xml"},
-                timeout=10,
-            )
-            if r.status_code != requests.codes.ok:
-                raise CouldNotSetPresetException(
-                    "Could not set the given "
-                    "preset: " + r.text
-                )
-            return r.text
-
-    def get_boiler_status(self, root):
-        """Gets the active boiler-heating status (On-Off control)"""
+    @staticmethod
+    def get_boiler_status(root):
+        """Get the active boiler-heating status (On-Off control)."""
         log_type = "boiler_state"
         locator = (
             "appliance[type='heater_central']/logs/point_log[type='"
@@ -322,9 +276,10 @@ class Haanna(object):
         if root.find(locator) is not None:
             return root.find(locator).text == "on"
         return None
-        
-    def get_heating_status(self, root):
-        """Gets the active heating status (OpenTherm control)"""
+
+    @staticmethod
+    def get_heating_status(root):
+        """Get the active heating status (OpenTherm control)."""
         log_type = "central_heating_state"
         locator = (
             "appliance[type='heater_central']/logs/point_log[type='"
@@ -335,8 +290,9 @@ class Haanna(object):
             return root.find(locator).text == "on"
         return None
 
-    def get_cooling_status(self, root):
-        """Gets the active cooling status"""
+    @staticmethod
+    def get_cooling_status(root):
+        """Get the active cooling status."""
         log_type = "cooling_state"
         locator = (
             "appliance[type='heater_central']/logs/point_log[type='"
@@ -348,63 +304,47 @@ class Haanna(object):
         return None
 
     def get_domestic_hot_water_status(self, root):
-        """Gets the domestic hot water status"""
+        """Get the domestic hot water status."""
         if self.legacy_anna:
             return None
-        else:
-            log_type = "domestic_hot_water_state"
-            locator = (
-                "appliance[type='heater_central']/logs/point_log[type='"
-                + log_type
-                + "']/period/measurement"
-            )
-            if root.find(locator) is not None:
-                return root.find(locator).text == "on"
-            return None
+        log_type = "domestic_hot_water_state"
+        locator = (
+            "appliance[type='heater_central']/logs/point_log[type='"
+            + log_type
+            + "']/period/measurement"
+        )
+        if root.find(locator) is not None:
+            return root.find(locator).text == "on"
+        return None
 
     def get_current_preset(self, root):
-        """Gets the current active preset"""
+        """Get the current active preset."""
         if self.legacy_anna:
-            active_rule = root.find(
-                "rule[active='true']/directives/when/then"
-            )
-            if (
-                active_rule is None
-                or "icon" not in active_rule.keys()
-            ):
-                """"No active preset"""
+            active_rule = root.find("rule[active='true']/directives/when/then")
+            if active_rule is None or "icon" not in active_rule.keys():
                 return "none"
-            else:
-                return active_rule.attrib["icon"]
+            return active_rule.attrib["icon"]
 
-        else:
-            log_type = "preset_state"
-            locator = (
-                "appliance[type='thermostat']/logs/point_log[type='"
-                + log_type
-                + "']/period/measurement"
-            )
-
-            return root.find(locator).text
+        log_type = "preset_state"
+        locator = (
+            "appliance[type='thermostat']/logs/point_log[type='"
+            + log_type
+            + "']/period/measurement"
+        )
+        return root.find(locator).text
 
     def get_schedule_temperature(self, root):
-        """Gets the temperature setting from the selected schedule"""
-        point_log_id = self.get_point_log_id(
-            root, "schedule_temperature"
-        )
+        """Get the temperature setting from the selected schedule."""
+        point_log_id = self.get_point_log_id(root, "schedule_temperature")
         if point_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, point_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, point_log_id)
             if measurement:
                 return float(measurement)
         return None
 
     def get_current_temperature(self, root):
-        """Gets the curent (room) temperature from the thermostat - match to HA name"""
-        current_temp_point_log_id = self.get_point_log_id(
-            root, "temperature"
-        )
+        """Get the curent (room) temperature from the thermostat - match to HA name."""
+        current_temp_point_log_id = self.get_point_log_id(root, "temperature")
         if current_temp_point_log_id:
             measurement = self.get_measurement_from_point_log(
                 root, current_temp_point_log_id
@@ -413,150 +353,113 @@ class Haanna(object):
         return None
 
     def get_target_temperature(self, root):
-        """Gets the target temperature from the thermostat"""
-        target_temp_log_id = self.get_point_log_id(
-            root, "target_temperature"
-        )
+        """Get the target temperature from the thermostat."""
+        target_temp_log_id = self.get_point_log_id(root, "target_temperature")
         if target_temp_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, target_temp_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
             return float(measurement)
         return None
 
     def get_thermostat_temperature(self, root):
-        """Gets the target temperature from the thermostat"""
-        thermostat_log_id = self.get_point_log_id(
-            root, "thermostat"
-        )
+        """Get the target temperature from the thermostat."""
+        thermostat_log_id = self.get_point_log_id(root, "thermostat")
         if thermostat_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, thermostat_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             return float(measurement)
         return None
 
     def get_outdoor_temperature(self, root):
-        """Gets the temperature from the thermostat"""
-        outdoor_temp_log_id = self.get_point_log_id(
-            root, "outdoor_temperature"
-        )
+        """Get the temperature from the thermostat."""
+        outdoor_temp_log_id = self.get_point_log_id(root, "outdoor_temperature")
         if outdoor_temp_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, outdoor_temp_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, outdoor_temp_log_id)
             value = float(measurement)
             value = round(value, 1)
             return value
         return None
 
     def get_illuminance(self, root):
-        """Gets the illuminance value from the thermostat"""
-        point_log_id = self.get_point_log_id(
-            root, "illuminance"
-        )
+        """Get the illuminance value from the thermostat."""
+        point_log_id = self.get_point_log_id(root, "illuminance")
         if point_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, point_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, point_log_id)
             value = float(measurement)
             value = round(value, 1)
             return value
         return None
 
     def get_boiler_temperature(self, root):
-        """Gets the boiler_temperature value from the thermostat"""
-        point_log_id = self.get_point_log_id(
-            root, "boiler_temperature"
-        )
+        """Get the boiler_temperature value from the thermostat."""
+        point_log_id = self.get_point_log_id(root, "boiler_temperature")
         if point_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, point_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, point_log_id)
             value = float(measurement)
             value = round(value, 1)
             return value
         return None
 
     def get_water_pressure(self, root):
-        """Gets the water pressure value from the thermostat"""
-        point_log_id = self.get_point_log_id(
-            root, "central_heater_water_pressure"
-        )
+        """Get the water pressure value from the thermostat."""
+        point_log_id = self.get_point_log_id(root, "central_heater_water_pressure")
         if point_log_id:
-            measurement = self.get_measurement_from_point_log(
-                root, point_log_id
-            )
+            measurement = self.get_measurement_from_point_log(root, point_log_id)
             return float(measurement)
         return None
 
     def __get_temperature_uri(self, root):
-        """Determine the set_temperature uri for different versions of Anna"""
+        """Determine the set_temperature uri for different versions of Anna."""
         if self.legacy_anna:
             locator = "appliance[type='thermostat']"
             appliance_id = root.find(locator).attrib["id"]
-            return (
-                ANNA_APPLIANCES
-                + ";id="
-                + appliance_id
-                + "/thermostat"
-            )
-        else:
-            locator = (
-                "appliance[type='thermostat']/location"
-            )
-            location_id = root.find(locator).attrib["id"]
-            locator = (
-                "location[@id='"
-                + location_id
-                + "']/actuator_functionalities/thermostat_functionality"
-            )
-            thermostat_functionality_id = root.find(
-                locator
-            ).attrib["id"]
+            return ANNA_APPLIANCES + ";id=" + appliance_id + "/thermostat"
+        locator = "appliance[type='thermostat']/location"
+        location_id = root.find(locator).attrib["id"]
+        locator = (
+            "location[@id='"
+            + location_id
+            + "']/actuator_functionalities/thermostat_functionality"
+        )
+        thermostat_functionality_id = root.find(locator).attrib["id"]
 
-            temperature_uri = (
-                ANNA_LOCATIONS_ENDPOINT
-                + ";id="
-                + location_id
-                + "/thermostat;id="
-                + thermostat_functionality_id
-            )
-            return temperature_uri
+        temperature_uri = (
+            ANNA_LOCATIONS_ENDPOINT
+            + ";id="
+            + location_id
+            + "/thermostat;id="
+            + thermostat_functionality_id
+        )
+        return temperature_uri
 
     def set_temperature(self, root, temperature):
-        """Sends a set request to the temperature with the given temperature"""
+        """Send a set request to the temperature with the given temperature."""
         uri = self.__get_temperature_uri(root)
 
         temperature = str(temperature)
 
-        r = requests.put(
-            self._endpoint + uri,
-            auth=(self._username, self._password),
-            data="<thermostat_functionality><setpoint>"
-            + temperature
-            + "</setpoint></thermostat_functionality>",
-            headers={"Content-Type": "text/xml"},
-            timeout=10,
+        xml = requests.put(
+              self._endpoint + uri,
+              auth=(self._username, self._password),
+              data="<thermostat_functionality><setpoint>"
+              + temperature
+              + "</setpoint></thermostat_functionality>",
+              headers={"Content-Type": "text/xml"},
+              timeout=10,
         )
 
-        if r.status_code != requests.codes.ok:
-            CouldNotSetTemperatureException(
-                "Could not set the temperature." + r.text
-            )
+        if xml.status_code != requests.codes.ok:  # pylint: disable=no-member
+            CouldNotSetTemperatureException("Could not set the temperature." + xml.text)
 
-        return r.text
-    
+        return xml.text
+
     def get_anna_endpoint(self):
-        return self._anna_endpoint
+        """Get the ANNA Endpoint."""
+        return self._endpoint
 
     @staticmethod
     def get_point_log_id(root, log_type):
-        """Gets the point log ID based on log type"""
+        """Get the point log ID based on log type."""
         locator = (
-            "module/services/*[@log_type='"
-            + log_type
-            + "']/functionalities/point_log"
+            "module/services/*[@log_type='" + log_type + "']/functionalities/point_log"
         )
         if root.find(locator) is not None:
             return root.find(locator).attrib["id"]
@@ -564,18 +467,15 @@ class Haanna(object):
 
     @staticmethod
     def get_measurement_from_point_log(root, point_log_id):
-        """Gets the measurement from a point log based on point log ID"""
-        locator = (
-            "*/logs/point_log[@id='"
-            + point_log_id
-            + "']/period/measurement"
-        )
+        """Get the measurement from a point log based on point log ID."""
+        locator = "*/logs/point_log[@id='" + point_log_id + "']/period/measurement"
         if root.find(locator) is not None:
             return root.find(locator).text
         return None
 
-    def get_rule_id_by_name(self, root, rule_name):
-        """Gets the rule ID based on name"""
+    @staticmethod
+    def get_rule_id_by_name(root, rule_name):
+        """Get the rule ID based on name."""
         rules = root.findall("rule")
         for rule in rules:
             if rule.find("name").text == rule_name:
@@ -583,18 +483,11 @@ class Haanna(object):
 
     @staticmethod
     def get_preset_dictionary(root, rule_id):
-        """
-        Gets the presets from a rule based on rule ID and returns a dictionary
-        with all the key-value pairs
-        """
+        """Get the presets from a rule based on rule ID and returns a dictionary with all the key-value pairs."""
         preset_dictionary = {}
-        directives = root.find(
-            "rule[@id='" + rule_id + "']/directives"
-        )
+        directives = root.find("rule[@id='" + rule_id + "']/directives")
         for directive in directives:
-            preset_dictionary[
-                directive.attrib["preset"]
-            ] = float(
+            preset_dictionary[directive.attrib["preset"]] = float(
                 directive.find("then").attrib["setpoint"]
             )
         return preset_dictionary
@@ -602,52 +495,44 @@ class Haanna(object):
     @staticmethod
     def __get_preset_dictionary_v1(root):
         """
-        Gets the presets and returns a dictionary with all the key-value pairs
+        Get the presets and returns a dictionary with all the key-value pairs.
+
         Example output: {'away': 17.0, 'home': 20.0, 'vacation': 15.0,
-        'no_frost': 10.0, 'asleep': 15.0}
+        'no_frost': 10.0, 'asleep': 15.0}.
         """
         preset_dictionary = {}
-        directives = root.findall(
-            "rule/directives/when/then"
-        )
+        directives = root.findall("rule/directives/when/then")
         for directive in directives:
-            if (
-                directive is not None
-                and "icon" in directive.keys()
-            ):
-                preset_dictionary[
-                    directive.attrib["icon"]
-                ] = float(directive.attrib["temperature"])
+            if directive is not None and "icon" in directive.keys():
+                preset_dictionary[directive.attrib["icon"]] = float(
+                    directive.attrib["temperature"]
+                )
         return preset_dictionary
 
     @staticmethod
     def get_active_mode(root, schema_ids):
-        """Gets the mode from a (list of) rule id(s)"""
+        """Get the mode from a (list of) rule id(s)."""
         active = False
         for schema_id in schema_ids:
-            if (
-                root.find(
-                    "rule[@id='" + schema_id + "']/active"
-                ).text
-                == "true"
-            ):
+            if root.find("rule[@id='" + schema_id + "']/active").text == "true":
                 active = True
                 break
         return active
 
-    def get_active_name(self, root, schema_ids):
-        """Gets the active schema from a (list of) rule id(s)"""
+    @staticmethod
+    def get_active_name(root, schema_ids):
+        """Get the active schema from a (list of) rule id(s)."""
         active = None
-        schemas = {}
         for schema_id in schema_ids:
             locator = root.find("rule[@id='" + schema_id + "']/active")
             # Only one can be active
             if locator.text == "true":
                 active = root.find("rule[@id='" + schema_id + "']/name").text
                 return active
-        
-    def get_last_active_name(self, root, schema_ids):
-        """Gets the last active schema from a (list of) rule id(s)"""
+
+    @staticmethod
+    def get_last_active_name(root, schema_ids):
+        """Get the last active schema from a (list of) rule id(s)."""
         schemas = {}
         epoch = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
         date_format = "%Y-%m-%dT%H:%M:%S.%f%z"
@@ -655,35 +540,38 @@ class Haanna(object):
             schema_name = root.find("rule[@id='" + schema_id + "']/name").text
             schema_date = root.find("rule[@id='" + schema_id + "']/modified_date").text
             # Python 3.6 fix (%z %Z issue)
-            corrected = re.sub(r"([-+]\d{2}):(\d{2})(?:(\d{2}))?$", r"\1\2\3", schema_date, )
+            corrected = re.sub(
+                r"([-+]\d{2}):(\d{2})(?:(\d{2}))?$", r"\1\2\3", schema_date,
+            )
             schema_time = datetime.datetime.strptime(corrected, date_format)
             schemas[schema_name] = (schema_time - epoch).total_seconds()
         last_modified = sorted(schemas.items(), key=lambda kv: kv[1])[-1][0]
         return last_modified
 
+
 class AnnaException(Exception):
+    """Define Exceptions."""
+
     def __init__(self, arg1, arg2=None):
-        """Base exception for interaction with the Anna gateway"""
+        """Set the base exception for interaction with the Anna gateway."""
         self.arg1 = arg1
         self.arg2 = arg2
         super(AnnaException, self).__init__(arg1)
 
 
 class RuleIdNotFoundException(AnnaException):
-    """
-    Raise an exception for when the rule id is not found in the direct objects
-    """
+    """Raise an exception for when the rule id is not found in the direct objects."""
 
     pass
 
 
 class CouldNotSetPresetException(AnnaException):
-    """Raise an exception for when the preset can not be set"""
+    """Raise an exception for when the preset can not be set."""
 
     pass
 
 
 class CouldNotSetTemperatureException(AnnaException):
-    """Raise an exception for when the temperature could not be set"""
+    """Raise an exception for when the temperature could not be set."""
 
     pass

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -351,6 +351,7 @@ class Haanna:
                 root, current_temp_point_log_id
             )
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 
@@ -369,6 +370,7 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -361,7 +361,6 @@ class Haanna:
         if target_temp_log_id:
             measurement = self.get_measurement_from_point_log(root, target_temp_log_id)
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value  
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -351,6 +351,7 @@ class Haanna:
                 root, current_temp_point_log_id
             )
             value = float(measurement)
+            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -351,7 +351,6 @@ class Haanna:
                 root, current_temp_point_log_id
             )
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -371,7 +371,6 @@ class Haanna:
         if thermostat_log_id:
             measurement = self.get_measurement_from_point_log(root, thermostat_log_id)
             value = float(measurement)
-            value = '{:.1f}'.format(round(value, 1))
             return value
         return None
 

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -340,7 +340,6 @@ class Haanna:
             measurement = self.get_measurement_from_point_log(root, point_log_id)
             if measurement:
                 value = float(measurement)
-                value = '{:.1f}'.format(round(value, 1))
                 return value
         return None
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.15',
+    version='0.14.1',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.3',
+    version='0.14.4',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.8',
+    version='0.14.9',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.12',
+    version='0.14.13',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.6',
+    version='0.14.7',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.9',
+    version='0.14.10',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.4',
+    version='0.14.5',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.14',
+    version='0.14.15',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.13',
+    version='0.14.14',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.2',
+    version='0.14.3',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.5',
+    version='0.14.6',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.11',
+    version='0.14.12',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.7',
+    version='0.14.8',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.10',
+    version='0.14.11',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.0',
+    version='0.14.1',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.1',
+    version='0.14.2',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',


### PR DESCRIPTION
Reason for change: at present the plugwise climate entity shows always a selected_schema name, also when no schema is active.
By implementing this change, this issue can be fixed. And the result of get_last_active_schema can be used as input to the set_schema_state function.