### PR TITLE
Fix (not) getting last_active_schema for legacy anna

### DIFF
--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -160,6 +160,8 @@ class Haanna:
 
     def get_last_active_schema_name(self, root):
         """Determine the last active schema (not used for legacy Anna)."""
+        if self.legacy_anna:
+            return None
         locator = "zone_preset_based_on_time_and_presence_with_override"
         rule_id = self.get_rule_id_by_template_tag(root, locator)
         last_schema_active = self.get_last_active_name(root, rule_id)

--- a/haanna/haanna.py
+++ b/haanna/haanna.py
@@ -153,19 +153,17 @@ class Haanna:
 
         locator = "zone_preset_based_on_time_and_presence_with_override"
         rule_id = self.get_rule_id_by_template_tag(root, locator)
-        if rule_id is None:
-            return None
-        schema_active = self.get_active_name(root, rule_id)
-        return schema_active
+        if rule_id:
+            schema_active = self.get_active_name(root, rule_id)
+            return schema_active
 
     def get_last_active_schema_name(self, root):
         """Determine the last active schema (not used for legacy Anna)."""
-        if self.legacy_anna:
-            return None
-        locator = "zone_preset_based_on_time_and_presence_with_override"
-        rule_id = self.get_rule_id_by_template_tag(root, locator)
-        last_schema_active = self.get_last_active_name(root, rule_id)
-        return last_schema_active
+        if not self.legacy_anna:
+            locator = "zone_preset_based_on_time_and_presence_with_override"
+            rule_id = self.get_rule_id_by_template_tag(root, locator)
+            last_schema_active = self.get_last_active_name(root, rule_id)
+            return last_schema_active
 
     @staticmethod
     def get_schema_state(root):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='haanna',
-    version='0.14.1',
+    version='0.14.2',
     description='Plugwise Anna API to use in conjunction with Home Assistant.',
     long_description='Plugwise Anna API to use in conjunction with Home Assistant, but it can also be used without Home Assistant.',
     keywords='HomeAssistant HA Home Assistant Anna Plugwise',


### PR DESCRIPTION
I forgot to disable this function for legacy anna, causing issues as reported at various places.